### PR TITLE
Made bash script more bulletproof

### DIFF
--- a/.ebextensions/9-letsencrypt-ssl-install.sh
+++ b/.ebextensions/9-letsencrypt-ssl-install.sh
@@ -14,16 +14,16 @@ if [ "$LE_INSTALL_SSL_ON_DEPLOY" = true ] ; then
     sudo yum -y install jq
 
     # Assign value to DOCUMENT_ROOT
-    DOCUMENT_ROOT=`sudo /opt/elasticbeanstalk/bin/get-config optionsettings | jq '."aws:elasticbeanstalk:container:php:phpini"."document_root"' -r`
+    DOCUMENT_ROOT=$(sudo /opt/elasticbeanstalk/bin/get-config optionsettings | jq '."aws:elasticbeanstalk:container:php:phpini"."document_root"' -r)
 
 
     # Install certbot
     sudo mkdir /certbot
-    cd /certbot
+    cd /certbot || exit
     wget https://dl.eff.org/certbot-auto;chmod a+x certbot-auto
 
     # Create certificate
-    sudo ./certbot-auto certonly -d $LE_SSL_DOMAIN --agree-tos --email $LE_EMAIL --webroot --webroot-path /var/app/current$DOCUMENT_ROOT --debug --non-interactive --renew-by-default
+    sudo ./certbot-auto certonly -d "$LE_SSL_DOMAIN" --agree-tos --email "$LE_EMAIL" --webroot --webroot-path /var/app/current"$DOCUMENT_ROOT" --debug --non-interactive --renew-by-default
 
     # Configure ssl.conf
     sudo mv /etc/httpd/conf.d/ssl.conf.template /etc/httpd/conf.d/ssl.conf


### PR DESCRIPTION
Backticks are [deprecated](http://pubs.opengroup.org/onlinepubs/9699919799/xrat/V4_xcu_chap02.html#tag_23_02_06_03) and can in some cases result in erroneous behaviour

Enclosing variables into double-quotes [preserves](https://www.gnu.org/software/bash/manual/html_node/Double-Quotes.html) the value of those variables.

`cd` should be accompanied with `exit` in case `cd` will fail.